### PR TITLE
Fixed Job Filter Status Comparison

### DIFF
--- a/nvidia_clara/jobs_client.py
+++ b/nvidia_clara/jobs_client.py
@@ -389,8 +389,8 @@ class JobsClient(BaseClient, JobsClientStub):
             if job_filter.has_job_status is not None:
                 if len(job_filter.has_job_status) > 0:
                     for status in job_filter.has_job_status:
-                        if (status.value < job_types.JobStatus.Minimum.value) or (
-                                status.value > job_types.JobStatus.Maximum.value):
+                        if (status.value[0] < job_types.JobStatus.Minimum.value[0]) or (
+                                status.value[0] > job_types.JobStatus.Maximum.value[0]):
                             raise Exception("Job status in filter must be within " + str(
                                 job_types.JobStatus.Minimum) + " and " + str(
                                 job_types.JobStatus.Maximum) + ", found:" + str(status))


### PR DESCRIPTION
The value of the GRPC Job Status type is in the form of a tuple, therefore needs to be indexed for proper comparison