### PR TITLE
Adding Ability to Retrieve Job Operator Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ $ python3 -m pip install claraclient
 >>> job_list = jobs_client.list_jobs(job_filter=job_filter)
 [<job_types.JobInfo object at 0x058908E0>, <job_types.JobInfo object at 0x063208E0>]
 
-# Identifier of created pipeline (ex. HQS)
->>> hqs_pipeline_id = "dd05c5b79461402cb0a610d4f0fce36f"
+# Identifier of created pipeline (ex. colon tumor segmentation)
+>>> colon_tumor_pipeline_id = "dd05c5b79461402cb0a610d4f0fce36f"
 
 # Create Job
->>> job_info = jobs_client.create_job(job_name="hqstest",pipeline_id=pipeline_types.PipelineId(hqs_pipeline_id))
+>>> job_info = jobs_client.create_job(job_name="colontumor",pipeline_id=pipeline_types.PipelineId(colon_tumor_pipeline_id))
 <job_types.JobInfo object at 0x05369B78>
 
 >>> job_info.job_id.value
@@ -69,6 +69,10 @@ $ python3 -m pip install claraclient
 
 >>> job_token.job_status
 1
+
+# Gets List of Operators
+>>> job_details.operator_details.keys()
+["colon-tumor-segmentation","dicom-reader","dicom-writer","register-dicom-output","register-volume-images-for-rendering"]
 
 # Get Status of Job from Identifier
 >>> job_details = jobs_client.get_status(job_id=job_token.job_id)

--- a/examples/jobs_client_example.py
+++ b/examples/jobs_client_example.py
@@ -29,11 +29,11 @@ job_filter = job_types.JobFilter(has_job_status=[job_types.JobStatus.Healthy])
 job_list = jobs_client.list_jobs(job_filter=job_filter)
 print(job_list)
 
-# Identifier of created pipeline (ex. HQS)
-hqs_pipeline_id = "f9a843935e654a30beb9d1b8352bfaac"
+# Identifier of created pipeline (ex. colon tumor segmentation)
+colon_tumor_pipeline_id = "f9a843935e654a30beb9d1b8352bfaac"
 
 # Create Job
-job_info = jobs_client.create_job(job_name="hqstest",pipeline_id=pipeline_types.PipelineId(hqs_pipeline_id))
+job_info = jobs_client.create_job(job_name="colontumor",pipeline_id=pipeline_types.PipelineId(colon_tumor_pipeline_id))
 print(job_info.job_id.value)
 
 # Start Job
@@ -46,6 +46,9 @@ job_details = jobs_client.get_status(job_id=job_token.job_id)
 
 print(job_details.job_state)
 print(job_details.job_status)
+
+# Gets List of Operators
+print(job_details.operator_details.keys())
 
 # Try Canceling Job (if still running)
 try:

--- a/nvidia_clara/job_types.py
+++ b/nvidia_clara/job_types.py
@@ -14,10 +14,12 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import List
+from typing import List, Mapping, TypeVar
 from nvidia_clara.grpc import common_pb2, jobs_pb2
 import nvidia_clara.payload_types as payload_types
 import nvidia_clara.pipeline_types as pipeline_types
+
+T = TypeVar('T')
 
 
 class JobPriority(Enum):
@@ -346,7 +348,8 @@ class JobDetails(JobInfo):
     def __init__(self, job_id: JobId = None, job_state: JobState = None, job_status: JobStatus = None,
                  job_priority: JobPriority = None, date_created: datetime = None, date_started: datetime = None,
                  date_stopped: datetime = None, name: str = None, payload_id: payload_types.PayloadId = None,
-                 pipeline_id: pipeline_types.PipelineId = None, messages: List[str] = None):
+                 pipeline_id: pipeline_types.PipelineId = None, operator_details: Mapping[str, Mapping[str, T]] = None,
+                 messages: List[str] = None):
         super().__init__(
             job_id=job_id,
             job_state=job_state,
@@ -360,6 +363,7 @@ class JobDetails(JobInfo):
             pipeline_id=pipeline_id
         )
         self._messages = messages
+        self._operator_details = operator_details
 
     @property
     def messages(self) -> List[str]:
@@ -370,3 +374,13 @@ class JobDetails(JobInfo):
     def messages(self, messages: List[str]):
         """List of messages reported by the job."""
         self._messages = messages
+
+    @property
+    def operator_details(self) -> Mapping[str, Mapping[str, T]]:
+        """Dictionary mapping operator names to operator details"""
+        return self._operator_details
+
+    @operator_details.setter
+    def operator_details(self, operator_details: Mapping[str, Mapping[str, T]]):
+        """Dictionary mapping operator names to operator details"""
+        self._operator_details = operator_details

--- a/nvidia_clara/jobs_client.py
+++ b/nvidia_clara/jobs_client.py
@@ -327,6 +327,16 @@ class JobsClient(BaseClient, JobsClientStub):
 
         self.check_response_header(header=response.header)
 
+        resp_operator_details = response.operator_details
+        operator_details = {}
+
+        for item in resp_operator_details:
+            operator_details[item.name] = {}
+            operator_details[item.name]["created"] = item.created
+            operator_details[item.name]["started"] = item.started
+            operator_details[item.name]["stopped"] = item.stopped
+            operator_details[item.name]["status"] = item.status
+
         result = job_types.JobDetails(
             job_id=job_types.JobId(response.job_id.value),
             job_priority=response.priority,
@@ -338,6 +348,7 @@ class JobsClient(BaseClient, JobsClientStub):
             date_created=self.get_timestamp(response.created),
             date_started=self.get_timestamp(response.started),
             date_stopped=self.get_timestamp(response.stopped),
+            operator_details=operator_details,
             messages=response.messages
         )
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="claraclient",
-    version="0.7.6",
+    version="0.7.7",
     author="NVIDIA Clara Deploy",
     description="Python package to interact with Clara Platform Server API",
     license='Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)',


### PR DESCRIPTION
The get_status() method under the jobs_client.py now returns a dictionary part of the job_types.JobDetails object returned. The dictionary maps operator names to its respective operator details.