### PR TITLE
Methods to return a list or stream of GPU utilization from platform

### DIFF
--- a/examples/clara_client_example.py
+++ b/examples/clara_client_example.py
@@ -23,8 +23,11 @@ clara_client = ClaraClient(target=clara_ip_address, port=clara_port)
 # Get Clara Version
 version = clara_client.version()
 
-# Get Gpu Utilization
-utilization_list = clara_client.utilization()
+# Getting Gpu Utilization
+# Option 1: Getting list which will give snapshot of current GPU Utilization
+utilization_list = clara_client.list_utilization()
+# Option 2: Obtaining generator which will provide steam of GPU Utilization
+utilization_stream = clara_client.stream_utilization()
 
 # Stop Pipeline Service and Triton
 clara_client.stop()

--- a/nvidia_clara/clara_types.py
+++ b/nvidia_clara/clara_types.py
@@ -70,7 +70,6 @@ class ClaraVersionInfo:
 
 class ClaraProcessDetails:
     def __init__(self, name: str = None, job_id: JobId = None):
-
         self._name = name
         self._job_id = job_id
 
@@ -111,8 +110,10 @@ class ClaraGpuUtilization:
 
     def __init__(self, node_id: int = None, pcie_id: int = None, compute_utilization: float = None,
                  memory_free: int = None, memory_used: int = None, memory_utilization: float = None,
-                 process_details: List[ClaraProcessDetails] = [], timestamp: datetime = None):
+                 process_details: List[ClaraProcessDetails] = None, timestamp: datetime = None):
         """GPU Utilization details for a Clara process."""
+        if process_details is None:
+            process_details = []
         self._node_id = node_id
         self._pcie_id = pcie_id
         self._compute_utilization = compute_utilization
@@ -135,7 +136,7 @@ class ClaraGpuUtilization:
     @property
     def pcie_id(self) -> int:
         """PCIE device identifier of the GPU."""
-        return self._node_id
+        return self._pcie_id
 
     @pcie_id.setter
     def pcie_id(self, pcie_id: int):
@@ -205,7 +206,10 @@ class ClaraGpuUtilization:
 
 class ClaraUtilizationDetails:
     """Utilization details for a Clara process."""
-    def __init__(self, gpu_metrics: List[ClaraGpuUtilization] = []):
+
+    def __init__(self, gpu_metrics: List[ClaraGpuUtilization] = None):
+        if gpu_metrics is None:
+            gpu_metrics = []
         self._gpu_metrics = gpu_metrics
 
     @property

--- a/nvidia_clara/job_types.py
+++ b/nvidia_clara/job_types.py
@@ -218,13 +218,16 @@ class JobInfo(JobToken):
     def __init__(self, job_id: JobId = None, job_state: JobState = None, job_status: JobStatus = None,
                  job_priority: JobPriority = None, date_created: datetime = None, date_started: datetime = None,
                  date_stopped: datetime = None, name: str = None, payload_id: payload_types.PayloadId = None,
-                 pipeline_id: pipeline_types.PipelineId = None, metadata: Mapping[str, str] = dict()):
+                 pipeline_id: pipeline_types.PipelineId = None, metadata: Mapping[str, str] = None):
         super().__init__(
             job_id=job_id,
             job_state=job_state,
             job_status=job_status,
             job_priority=job_priority,
         )
+        if metadata is None:
+            metadata = dict()
+
         self._date_created = date_created
         self._date_started = date_started
         self._date_stopped = date_stopped
@@ -299,8 +302,15 @@ class JobInfo(JobToken):
 class JobFilter:
 
     def __init__(self, completed_before: datetime = None, created_after: datetime = None,
-                 has_job_state: List[JobState] = [], has_job_status: List[JobStatus] = [],
-                 pipeline_ids: List[pipeline_types.PipelineId] = []):
+                 has_job_state: List[JobState] = None, has_job_status: List[JobStatus] = None,
+                 pipeline_ids: List[pipeline_types.PipelineId] = None):
+        if has_job_state is None:
+            has_job_state = []
+        if has_job_status is None:
+            has_job_status = []
+        if pipeline_ids is None:
+            pipeline_ids = []
+
         self._completed_before = completed_before
         self._created_after = created_after
         self._has_job_state = has_job_state
@@ -363,8 +373,11 @@ class JobDetails(JobInfo):
     def __init__(self, job_id: JobId = None, job_state: JobState = None, job_status: JobStatus = None,
                  job_priority: JobPriority = None, date_created: datetime = None, date_started: datetime = None,
                  date_stopped: datetime = None, name: str = None, payload_id: payload_types.PayloadId = None,
-                 pipeline_id: pipeline_types.PipelineId = None, operator_details: Mapping[str, Mapping[str, T]] = dict(),
-                 messages: List[str] = [], metadata: Mapping[str, str] = dict()):
+                 pipeline_id: pipeline_types.PipelineId = None, operator_details: Mapping[str, Mapping[str, T]] = None,
+                 messages: List[str] = None, metadata: Mapping[str, str] = None):
+        if metadata is None:
+            metadata = dict()
+
         super().__init__(
             job_id=job_id,
             job_state=job_state,
@@ -378,6 +391,12 @@ class JobDetails(JobInfo):
             pipeline_id=pipeline_id,
             metadata=metadata
         )
+
+        if messages is None:
+            messages = []
+        if operator_details is None:
+            operator_details = dict()
+
         self._messages = messages
         self._operator_details = operator_details
 

--- a/nvidia_clara/model_types.py
+++ b/nvidia_clara/model_types.py
@@ -103,9 +103,13 @@ class ModelId:
 class ModelDetails:
 
     def __init__(self, other: models_pb2.ModelDetails = None, model_id: ModelId = None, name: str = None,
-                 tags: Mapping[str, str] = dict(),
-                 model_type: ModelType = None, metadata: Mapping[str, str] = dict()):
+                 tags: Mapping[str, str] = None,
+                 model_type: ModelType = None, metadata: Mapping[str, str] = None):
         if other is None:
+            if tags is None:
+                tags = dict()
+            if metadata is None:
+                metadata = dict()
             self._model_id = model_id
             self._name = name
             self._tags = tags
@@ -176,7 +180,7 @@ class ModelDetails:
 class CatalogDetails:
 
     def __init__(self, other: models_pb2.ModelCatalogDetails = None, catalog_id: CatalogId = None,
-                 models: List[ModelDetails] = []):
+                 models: List[ModelDetails] = None):
         if other is None:
             if catalog_id is None:
                 raise Exception("Catalog identifier can not be None and must be initializes")
@@ -257,7 +261,7 @@ class InstanceId:
 
 class InstanceDetails:
     def __init__(self, other: models_pb2.ModelCatalogDetails = None, instance_id: InstanceId = None,
-                 models: List[ModelDetails] = []):
+                 models: List[ModelDetails] = None):
         if other is None:
             if instance_id is None:
                 raise Exception("Instance identifier can not be None and must be initializes")

--- a/nvidia_clara/payload_types.py
+++ b/nvidia_clara/payload_types.py
@@ -147,8 +147,13 @@ class PayloadId:
 
 class PayloadDetails:
 
-    def __init__(self, payload_id: PayloadId = None, file_details: List[PayloadFileDetails] = [],
-                 payload_type: payloads_pb2.PayloadType = None, metadata: Mapping[str, str] = dict()):
+    def __init__(self, payload_id: PayloadId = None, file_details: List[PayloadFileDetails] = None,
+                 payload_type: payloads_pb2.PayloadType = None, metadata: Mapping[str, str] = None):
+        if file_details is None:
+            file_details = []
+        if metadata is None:
+            metadata = dict()
+
         self._payload_id = payload_id
         self._file_details = file_details
         self._payload_type = payload_type

--- a/nvidia_clara/pipeline_types.py
+++ b/nvidia_clara/pipeline_types.py
@@ -92,8 +92,12 @@ class PipelineId:
 
 class PipelineDetails:
 
-    def __init__(self, pipeline_id: PipelineId = None, name: str = None, definition: List[PipelineDefinition] = [],
-                 metadata: Mapping[str, str] = dict()):
+    def __init__(self, pipeline_id: PipelineId = None, name: str = None, definition: List[PipelineDefinition] = None,
+                 metadata: Mapping[str, str] = None):
+        if definition is None:
+            definition = []
+        if metadata is None:
+            metadata = dict()
         self._pipeline_id = pipeline_id
         self._name = name
         self._definition = definition
@@ -162,7 +166,9 @@ class PipelineDetails:
 
 class PipelineInfo:
 
-    def __init__(self, pipeline_id: PipelineId = None, name: str = None, metadata: Mapping[str, str] = dict()):
+    def __init__(self, pipeline_id: PipelineId = None, name: str = None, metadata: Mapping[str, str] = None):
+        if metadata is None:
+            metadata = dict()
         self._pipeline_id = pipeline_id
         self._name = name
         self._metadata = metadata

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="claraclient",
-    version="0.7.7.1",
+    version="0.7.7.2",
     author="NVIDIA Clara Deploy",
     description="Python package to interact with Clara Platform Server API",
     license='Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)',


### PR DESCRIPTION
Initial code implemented incorrectly to support streaming output of GPU utilization details. Client now has 2 methods: one to get current snapshot of GPU utilization in a list, and the other will return a generator so responses can be streamed.