### PR TITLE
list_jobs() under Jobs Client updated with new fields

### DIFF
--- a/nvidia_clara/jobs_client.py
+++ b/nvidia_clara/jobs_client.py
@@ -476,9 +476,9 @@ class JobsClient(BaseClient, JobsClientStub):
                     name=item.job_details.job_name,
                     payload_id=payload_types.PayloadId(item.job_details.payload_id.value),
                     pipeline_id=pipeline_types.PipelineId(item.job_details.pipeline_id.value),
-                    date_created=self.get_timestamp(item.job_details.timestamp_created),
-                    date_started=self.get_timestamp(item.job_details.timestamp_started),
-                    date_stopped=self.get_timestamp(item.job_details.timestamp_stopped),
+                    date_created=self.get_timestamp(item.job_details.created),
+                    date_started=self.get_timestamp(item.job_details.started),
+                    date_stopped=self.get_timestamp(item.job_details.stopped),
                     metadata=item.job_details.metadata
                 )
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="claraclient",
-    version="0.7.7.2",
+    version="0.8.1",
     author="NVIDIA Clara Deploy",
     description="Python package to interact with Clara Platform Server API",
     license='Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)',


### PR DESCRIPTION
Platform GRPC API for listing jobs had new fields for job created, started, and stopped timestamps. Python API now reflects these changes.