### PR TITLE
Acceptance of Timezone Aware Datetimes in Jobs Filter

### DIFF
--- a/nvidia_clara/jobs_client.py
+++ b/nvidia_clara/jobs_client.py
@@ -420,11 +420,21 @@ class JobsClient(BaseClient, JobsClientStub):
             request_filter = jobs_pb2.JobsListRequest.JobFilter
 
             if job_filter.completed_before is not None:
-                seconds = (job_filter.completed_before - datetime.datetime(1, 1, 1)).total_seconds()
+                day_one = datetime.datetime(1, 1, 1)
+                if job_filter.completed_before.tzinfo is not None \
+                        and job_filter.completed_before.tzinfo.utcoffset(job_filter.completed_before) is not None:
+                    day_one = datetime.datetime(1, 1, 1, tzinfo=job_filter.completed_before.tzinfo)
+
+                seconds = (job_filter.completed_before - day_one).total_seconds()
                 request.filter.completed_before.value = int(seconds)
 
             if job_filter.created_after is not None:
-                seconds = (job_filter.created_after - datetime.datetime(1, 1, 1)).total_seconds()
+                day_one = datetime.datetime(1, 1, 1)
+                if job_filter.created_after.tzinfo is not None \
+                        and job_filter.created_after.tzinfo.utcoffset(job_filter.created_after) is not None:
+                    day_one = datetime.datetime(1, 1, 1, tzinfo=job_filter.created_after.tzinfo)
+
+                seconds = (job_filter.created_after - day_one).total_seconds()
                 request.filter.created_after.value = int(seconds)
 
             if job_filter.has_job_state is not None:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="nvidia-clara-client",
-    version="0.8.1.2",
+    version="0.8.1.3",
     author="NVIDIA Clara Deploy",
     description="Python package to interact with Clara Platform Server API",
     license='Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)',


### PR DESCRIPTION
The filter for JobsClient.list_jobs() would not accept datetime objects with a timezone parameter. Client code has been fixed so this is not an issue.