### PR TITLE
Minor Documentation Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ An intuitive python 3 package to develop applications with NVIDIA Clara Deploy. 
 ### Package Installation
 #### Installing from [source repository](https://github.com/NVIDIA/clara-platform-python-client)
 ```
-$ git clone --recursive git@github.com:kubernetes-client/python.git
+$ git clone --recursive git@github.com:NVIDIA/clara-platform-python-client.git
 $ cd ./clara-platform-python-client
 $ python3 -m pip install .
 ```

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="nvidia-clara-client",
-    version="0.8.1.4",
+    version="0.8.1.5",
     author="NVIDIA Clara Deploy",
     description="Python package to interact with Clara Platform Server API",
     license='Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)',


### PR DESCRIPTION
Repository `git clone` example was pointing to the wrong place